### PR TITLE
- Switched hadoop mirror as the previously used mirror is no longer a…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # python-spark
 
-This image is based off the [`python:2.7`](https://hub.docker.com/_/python/) image and
+This image is based off the [`iron/python:2`](https://hub.docker.com/iron/python/) image and
 contains Hadoop, Sqoop and Spark binaries.
 
 This is used as a base image for [`airflow-pipeline`](https://github.com/datagovsg/airflow-pipeline), a simplified setup for Airflow to launch Hadoop and Spark jobs.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # python-spark
 
-This image is based off the [`iron/python:2`](https://hub.docker.com/iron/python/) image and
+This image is based off the [`iron/python:2`](https://hub.docker.com/r/iron/python/) image and
 contains Hadoop, Sqoop and Spark binaries.
 
 This is used as a base image for [`airflow-pipeline`](https://github.com/datagovsg/airflow-pipeline), a simplified setup for Airflow to launch Hadoop and Spark jobs.

--- a/python2/spark1.6/Dockerfile
+++ b/python2/spark1.6/Dockerfile
@@ -1,21 +1,11 @@
-FROM python:2.7
+FROM iron/python:2
 
-# Setup Java
-RUN set -x && \
-    apt-get update && \
-    apt-get install --no-install-recommends -y software-properties-common && \
-    echo "deb http://ppa.launchpad.net/webupd8team/java/ubuntu xenial main"  > \
-        /etc/apt/sources.list.d/webupd8team-java.list && \
-    echo "deb-src http://ppa.launchpad.net/webupd8team/java/ubuntu xenial main" >> \
-        /etc/apt/sources.list.d/webupd8team-java.list && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys EEA14886 && \
-    echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections && \
-    apt-get update && echo yes | apt-get install -y --force-yes oracle-java8-installer && \
-    apt-get update && apt-get install oracle-java8-set-default && \
-    apt-get remove software-properties-common -y --auto-remove && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-ENV JAVA_HOME /usr/lib/jvm/java-8-oracle
+# Install python pip
+RUN wget -qO - https://bootstrap.pypa.io/get-pip.py | python
+
+# Setup Java & SSL
+RUN echo http://dl-cdn.alpinelinux.org/alpine/v3.6/community >> /etc/apk/repositories && apk --update add openjdk8-jre openssl libc6-compat && rm -rf /var/cache/apk/*
+ENV JAVA_HOME /usr/lib/jvm/java-1.8-openjdk
 
 ARG HADOOP_VERSION=2.6.1
 ARG SPARK_VERSION=1.6.1
@@ -58,9 +48,9 @@ ENV SQOOP_HOME /opt/sqoop
 ENV PATH ${PATH}:${SQOOP_HOME}/bin:${HADOOP_HOME}/bin
 
 # Download binaries
-RUN /bin/bash -c 'set -x && \
+RUN mkdir /opt/ && /bin/sh -c 'set -x && \
     echo "Downloading Hadoop ${HADOOP_VERSION}" && \
-    wget -qO - http://apache.stu.edu.tw/hadoop/common/hadoop-${HADOOP_VERSION}/hadoop-${HADOOP_VERSION}.tar.gz | \
+    wget -qO - http://www-us.apache.org/dist/hadoop/common/hadoop-${HADOOP_VERSION}/hadoop-${HADOOP_VERSION}.tar.gz | \
         tar -xz -C /opt/ && \
     mv /opt/hadoop-${HADOOP_VERSION} /opt/hadoop && \
     echo "Downloading Spark ${SPARK_VERSION} for Hadoop ${HADOOP_VERSION:0:3}" && \
@@ -90,6 +80,7 @@ RUN /bin/bash -c 'set -x && \
 EXPOSE 8080 7077 8888 8081 4040 7001 7002 7003 7004 7005 7006
 
 # Install kerberos client support
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y krb5-user
+RUN DEBIAN_FRONTEND=noninteractive apk --update add krb5 && rm -rf /var/cache/apk/*
 
-CMD '/bin/bash'
+CMD '/bin/sh'
+

--- a/python2/spark2.0/Dockerfile
+++ b/python2/spark2.0/Dockerfile
@@ -31,9 +31,9 @@ ENV SPARK_HOME=/opt/spark-${SPARK_VERSION}
 ENV PYSPARK_PYTHON=python
 ENV PATH=$PATH:${SPARK_HOME}/bin
 
-# Set Python Spark 1.6 specific settings
-ENV PYSPARK_SUBMIT_ARGS="--packages com.databricks:spark-csv_2.10:1.5.0,com.databricks:spark-avro_2.10:2.0.1,graphframes:graphframes:0.5.0-spark1.6-s_2.10 pyspark-shell"
-ENV PYTHONPATH=${SPARK_HOME}/python:${SPARK_HOME}/python/lib/py4j-0.9-src.zip
+# Set Python Spark 2 specific settings
+ENV PYSPARK_SUBMIT_ARGS="--packages com.databricks:spark-csv_2.11:1.5.0,com.databricks:spark-avro_2.11:3.1.0,graphframes:graphframes:0.5.0-spark2.0-s_2.11 pyspark-shell"
+ENV PYTHONPATH=${SPARK_HOME}/python:${SPARK_HOME}/python/lib/py4j-0.10.3-src.zip
 
 # Exposes the relevant ports and setup the port settings
 ENV SPARK_MASTER_OPTS="-Dspark.driver.port=7001 -Dspark.fileserver.port=7002 -Dspark.broadcast.port=7003 -Dspark.replClassServer.port=7004 -Dspark.blockManager.port=7005 -Dspark.executor.port=7006 -Dspark.ui.port=4040 -Dspark.broadcast.factory=org.apache.spark.broadcast.HttpBroadcastFactory"
@@ -58,8 +58,8 @@ RUN mkdir /opt/ && /bin/sh -c 'set -x && \
     tar -xz -C /opt/ && \
     mv /opt/spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION:0:3} /opt/spark-${SPARK_VERSION} && \
     echo "Downloading Spark packages" && \
-    wget -q http://repo1.maven.org/maven2/com/databricks/spark-avro_2.10/2.0.1/spark-avro_2.10-2.0.1.jar -P ${SPARK_HOME}/lib && \
-    wget -q http://repo1.maven.org/maven2/com/databricks/spark-csv_2.10/1.5.0/spark-csv_2.10-1.5.0.jar -P ${SPARK_HOME}/lib && \
+    wget -q http://repo1.maven.org/maven2/com/databricks/spark-avro_2.11/3.1.0/spark-avro_2.11-3.1.0.jar -P ${SPARK_HOME}/jars && \
+    wget -q http://repo1.maven.org/maven2/com/databricks/spark-csv_2.11/1.5.0/spark-csv_2.11-1.5.0.jar -P ${SPARK_HOME}/jars && \
     echo "Downloading Sqoop" && \
     wget -qO - http://www.apache.org/dist/sqoop/1.4.6/sqoop-1.4.6.bin__hadoop-2.0.4-alpha.tar.gz | tar -xz -C /opt && \
     cd /opt && ln -s ./sqoop-1.4.6.bin__hadoop-2.0.4-alpha sqoop && \

--- a/python3/spark1.6/Dockerfile
+++ b/python3/spark1.6/Dockerfile
@@ -1,21 +1,11 @@
-FROM python:3.5
+FROM iron/python:3
 
-# Setup Java
-RUN set -x && \
-    apt-get update && \
-    apt-get install --no-install-recommends -y software-properties-common && \
-    echo "deb http://ppa.launchpad.net/webupd8team/java/ubuntu xenial main"  > \
-        /etc/apt/sources.list.d/webupd8team-java.list && \
-    echo "deb-src http://ppa.launchpad.net/webupd8team/java/ubuntu xenial main" >> \
-        /etc/apt/sources.list.d/webupd8team-java.list && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys EEA14886 && \
-    echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections && \
-    apt-get update && echo yes | apt-get install -y --force-yes oracle-java8-installer && \
-    apt-get update && apt-get install oracle-java8-set-default && \
-    apt-get remove software-properties-common -y --auto-remove && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-ENV JAVA_HOME /usr/lib/jvm/java-8-oracle
+# Install python pip
+RUN wget -qO - https://bootstrap.pypa.io/get-pip.py | python3
+
+# Setup Java & SSL
+RUN echo http://dl-cdn.alpinelinux.org/alpine/v3.6/community >> /etc/apk/repositories && apk --update add openjdk8-jre openssl libc6-compat && rm -rf /var/cache/apk/*
+ENV JAVA_HOME /usr/lib/jvm/java-1.8-openjdk
 
 ARG HADOOP_VERSION=2.6.1
 ARG SPARK_VERSION=1.6.1
@@ -58,9 +48,9 @@ ENV SQOOP_HOME /opt/sqoop
 ENV PATH ${PATH}:${SQOOP_HOME}/bin:${HADOOP_HOME}/bin
 
 # Download binaries
-RUN /bin/bash -c 'set -x && \
+RUN mkdir /opt/ && /bin/sh -c 'set -x && \
     echo "Downloading Hadoop ${HADOOP_VERSION}" && \
-    wget -qO - http://apache.stu.edu.tw/hadoop/common/hadoop-${HADOOP_VERSION}/hadoop-${HADOOP_VERSION}.tar.gz | \
+    wget -qO -  http://www-us.apache.org/dist/hadoop/common/hadoop-${HADOOP_VERSION}/hadoop-${HADOOP_VERSION}.tar.gz | \
         tar -xz -C /opt/ && \
     mv /opt/hadoop-${HADOOP_VERSION} /opt/hadoop && \
     echo "Downloading Spark ${SPARK_VERSION} for Hadoop ${HADOOP_VERSION:0:3}" && \
@@ -90,6 +80,7 @@ RUN /bin/bash -c 'set -x && \
 EXPOSE 8080 7077 8888 8081 4040 7001 7002 7003 7004 7005 7006
 
 # Install kerberos client support
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y krb5-user
+RUN DEBIAN_FRONTEND=noninteractive apk --update add krb5 && rm -rf /var/cache/apk/*
 
-CMD '/bin/bash'
+CMD '/bin/sh'
+

--- a/python3/spark2.0/Dockerfile
+++ b/python3/spark2.0/Dockerfile
@@ -1,7 +1,7 @@
-FROM iron/python:2
+FROM iron/python:3
 
 # Install python pip
-RUN wget -qO - https://bootstrap.pypa.io/get-pip.py | python
+RUN wget -qO - https://bootstrap.pypa.io/get-pip.py | python3
 
 # Setup Java & SSL
 RUN echo http://dl-cdn.alpinelinux.org/alpine/v3.6/community >> /etc/apk/repositories && apk --update add openjdk8-jre openssl libc6-compat && rm -rf /var/cache/apk/*

--- a/python3/spark2.0/Dockerfile
+++ b/python3/spark2.0/Dockerfile
@@ -31,9 +31,9 @@ ENV SPARK_HOME=/opt/spark-${SPARK_VERSION}
 ENV PYSPARK_PYTHON=python
 ENV PATH=$PATH:${SPARK_HOME}/bin
 
-# Set Python Spark 1.6 specific settings
-ENV PYSPARK_SUBMIT_ARGS="--packages com.databricks:spark-csv_2.10:1.5.0,com.databricks:spark-avro_2.10:2.0.1,graphframes:graphframes:0.5.0-spark1.6-s_2.10 pyspark-shell"
-ENV PYTHONPATH=${SPARK_HOME}/python:${SPARK_HOME}/python/lib/py4j-0.9-src.zip
+# Set Python Spark 2 specific settings
+ENV PYSPARK_SUBMIT_ARGS="--packages com.databricks:spark-csv_2.11:1.5.0,com.databricks:spark-avro_2.11:3.1.0,graphframes:graphframes:0.5.0-spark2.0-s_2.11 pyspark-shell"
+ENV PYTHONPATH=${SPARK_HOME}/python:${SPARK_HOME}/python/lib/py4j-0.10.3-src.zip
 
 # Exposes the relevant ports and setup the port settings
 ENV SPARK_MASTER_OPTS="-Dspark.driver.port=7001 -Dspark.fileserver.port=7002 -Dspark.broadcast.port=7003 -Dspark.replClassServer.port=7004 -Dspark.blockManager.port=7005 -Dspark.executor.port=7006 -Dspark.ui.port=4040 -Dspark.broadcast.factory=org.apache.spark.broadcast.HttpBroadcastFactory"
@@ -58,8 +58,8 @@ RUN mkdir /opt/ && /bin/sh -c 'set -x && \
     tar -xz -C /opt/ && \
     mv /opt/spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION:0:3} /opt/spark-${SPARK_VERSION} && \
     echo "Downloading Spark packages" && \
-    wget -q http://repo1.maven.org/maven2/com/databricks/spark-avro_2.10/2.0.1/spark-avro_2.10-2.0.1.jar -P ${SPARK_HOME}/lib && \
-    wget -q http://repo1.maven.org/maven2/com/databricks/spark-csv_2.10/1.5.0/spark-csv_2.10-1.5.0.jar -P ${SPARK_HOME}/lib && \
+    wget -q http://repo1.maven.org/maven2/com/databricks/spark-avro_2.11/3.1.0/spark-avro_2.11-3.1.0.jar -P ${SPARK_HOME}/jars && \
+    wget -q http://repo1.maven.org/maven2/com/databricks/spark-csv_2.11/1.5.0/spark-csv_2.11-1.5.0.jar -P ${SPARK_HOME}/jars && \
     echo "Downloading Sqoop" && \
     wget -qO - http://www.apache.org/dist/sqoop/1.4.6/sqoop-1.4.6.bin__hadoop-2.0.4-alpha.tar.gz | tar -xz -C /opt && \
     cd /opt && ln -s ./sqoop-1.4.6.bin__hadoop-2.0.4-alpha sqoop && \


### PR DESCRIPTION
…vailable

- Switched from ubuntu based python to alpine based python (Note that `apk add -update` should be used in place of `apt-get update && apt-get install` now)
- Reduce to minimal openjdk jre 8
- Optimized the base image size from 1.9 GB to 800 MB
- Added python3 / spark2 branch