### PR TITLE
Use OpenJDK 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # python-spark
 
 This image is based off the [`python:2.7`](https://hub.docker.com/_/python/) image and
-contains Hadoop, Sqoop and Spark binaries. Installs Oracle Java 7.
+contains Hadoop, Sqoop and Spark binaries. Installs OpenJDK 7.
 
 This is used as a base image for [`airflow-pipeline`](https://github.com/datagovsg/airflow-pipeline), a simplified setup for Airflow to launch Hadoop and Spark jobs.
 
@@ -12,11 +12,11 @@ Useful packages included for Spark and Sqoop:
 - PostgreSQL JDBC driver
 - MS SQL JDBC driver
 
-## Kerberos support 
-Kerberos support has been added, but derivative images would need to update the kerberos configuration file in `/etc/krb5.conf`. To use spark with kerberos, the 
-environment variable `PYSPARK_SUBMIT_ARGS` should also be modified to specify the kerberos principal and location of the corresponding keytab. Derivative images 
-are responsible for putting in the keytab by mounting the volume containing the keytab into the image (suggested location: /etc/kerberos). So for example, if 
-the principal is `kerbuser` and the keytab is `kerbuser.keytab` in the default location, then `PYSPARK_SUBMIT_ARGS` would be 
+## Kerberos support
+Kerberos support has been added, but derivative images would need to update the kerberos configuration file in `/etc/krb5.conf`. To use spark with kerberos, the
+environment variable `PYSPARK_SUBMIT_ARGS` should also be modified to specify the kerberos principal and location of the corresponding keytab. Derivative images
+are responsible for putting in the keytab by mounting the volume containing the keytab into the image (suggested location: /etc/kerberos). So for example, if
+the principal is `kerbuser` and the keytab is `kerbuser.keytab` in the default location, then `PYSPARK_SUBMIT_ARGS` would be
 
 `[other spark parameters] --principal kerbuser --keytab /etc/kerberos/kerbuser.keytab pyspark-shell`
 

--- a/python2/spark1.6/Dockerfile
+++ b/python2/spark1.6/Dockerfile
@@ -3,21 +3,13 @@ FROM python:2.7
 # Setup Java
 RUN set -x && \
     apt-get update && \
-    apt-get install --no-install-recommends -y software-properties-common && \
-    echo "deb http://ppa.launchpad.net/webupd8team/java/ubuntu xenial main"  > \
-        /etc/apt/sources.list.d/webupd8team-java.list && \
-    echo "deb-src http://ppa.launchpad.net/webupd8team/java/ubuntu xenial main" >> \
-        /etc/apt/sources.list.d/webupd8team-java.list && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys EEA14886 && \
-    wget -q -P /tmp http://ftp.osuosl.org/pub/funtoo/distfiles/oracle-java/jdk-7u80-linux-x64.tar.gz && \
-    echo oracle-java7-installer oracle-java7-installer/local select /tmp | /usr/bin/debconf-set-selections && \
-    echo oracle-java7-installer shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections && \
-    apt-get update && echo yes | apt-get install -y --force-yes oracle-java7-installer && \
-    apt-get update && apt-get install oracle-java7-set-default && \
-    apt-get remove software-properties-common -y --auto-remove && \
+    apt-get install -y --force-yes openjdk-7-jdk && \
     apt-get clean && \
-    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-ENV JAVA_HOME /usr/lib/jvm/java-7-oracle
+    apt-get autoremove && \
+    rm -rf /var/cache/apk/* /var/lib/apt/lists/* && \
+    update-java-alternatives -s java-1.7.0-openjdk-amd64 && \
+    java -version
+ENV JAVA_HOME /usr/lib/jvm/java-7-openjdk-amd64
 
 ARG HADOOP_VERSION=2.6.1
 ARG SPARK_VERSION=1.6.1

--- a/python2/spark2.1/Dockerfile
+++ b/python2/spark2.1/Dockerfile
@@ -3,21 +3,13 @@ FROM python:2.7
 # Setup Java
 RUN set -x && \
     apt-get update && \
-    apt-get install --no-install-recommends -y software-properties-common && \
-    echo "deb http://ppa.launchpad.net/webupd8team/java/ubuntu xenial main"  > \
-        /etc/apt/sources.list.d/webupd8team-java.list && \
-    echo "deb-src http://ppa.launchpad.net/webupd8team/java/ubuntu xenial main" >> \
-        /etc/apt/sources.list.d/webupd8team-java.list && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys EEA14886 && \
-    wget -q -P /tmp http://ftp.osuosl.org/pub/funtoo/distfiles/oracle-java/jdk-7u80-linux-x64.tar.gz && \
-    echo oracle-java7-installer oracle-java7-installer/local select /tmp | /usr/bin/debconf-set-selections && \
-    echo oracle-java7-installer shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections && \
-    apt-get update && echo yes | apt-get install -y --force-yes oracle-java7-installer && \
-    apt-get update && apt-get install oracle-java7-set-default && \
-    apt-get remove software-properties-common -y --auto-remove && \
+    apt-get install -y --force-yes openjdk-7-jdk && \
     apt-get clean && \
-    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-ENV JAVA_HOME /usr/lib/jvm/java-8-oracle
+    apt-get autoremove && \
+    rm -rf /var/cache/apk/* /var/lib/apt/lists/* && \
+    update-java-alternatives -s java-1.7.0-openjdk-amd64 && \
+    java -version
+ENV JAVA_HOME /usr/lib/jvm/java-7-openjdk-amd64
 
 ARG HADOOP_VERSION=2.7.3
 ARG SPARK_VERSION=2.1.0

--- a/python3/spark1.6/Dockerfile
+++ b/python3/spark1.6/Dockerfile
@@ -3,21 +3,13 @@ FROM python:3.5
 # Setup Java
 RUN set -x && \
     apt-get update && \
-    apt-get install --no-install-recommends -y software-properties-common && \
-    echo "deb http://ppa.launchpad.net/webupd8team/java/ubuntu xenial main"  > \
-        /etc/apt/sources.list.d/webupd8team-java.list && \
-    echo "deb-src http://ppa.launchpad.net/webupd8team/java/ubuntu xenial main" >> \
-        /etc/apt/sources.list.d/webupd8team-java.list && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys EEA14886 && \
-    wget -q -P /tmp http://ftp.osuosl.org/pub/funtoo/distfiles/oracle-java/jdk-7u80-linux-x64.tar.gz && \
-    echo oracle-java7-installer oracle-java7-installer/local select /tmp | /usr/bin/debconf-set-selections && \
-    echo oracle-java7-installer shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections && \
-    apt-get update && echo yes | apt-get install -y --force-yes oracle-java7-installer && \
-    apt-get update && apt-get install oracle-java7-set-default && \
-    apt-get remove software-properties-common -y --auto-remove && \
+    apt-get install -y --force-yes openjdk-7-jdk && \
     apt-get clean && \
-    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-ENV JAVA_HOME /usr/lib/jvm/java-8-oracle
+    apt-get autoremove && \
+    rm -rf /var/cache/apk/* /var/lib/apt/lists/* && \
+    update-java-alternatives -s java-1.7.0-openjdk-amd64 && \
+    java -version
+ENV JAVA_HOME /usr/lib/jvm/java-7-openjdk-amd64
 
 ARG HADOOP_VERSION=2.6.1
 ARG SPARK_VERSION=1.6.1


### PR DESCRIPTION
- it provices JCE unlimited strength jurisdiction policy files, as Kerberos tickets may use AES-256 encryption by default
- the JCE policy files provided in standard Oracle JDK do not allow AES-256